### PR TITLE
OSS Multi-Output Risk Measures

### DIFF
--- a/botorch/acquisition/multi_objective/multi_output_risk_measures.py
+++ b/botorch/acquisition/multi_objective/multi_output_risk_measures.py
@@ -1,0 +1,446 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+r"""
+Multi-output extensions of the risk measures, implemented as Monte-Carlo
+objectives. Except for MVaR, the risk measures are computed over each
+output dimension independently. In contrast, MVaR is computed using the
+joint distribution of the outputs, and provides more accurate risk estimates.
+
+References
+
+.. [Prekopa2012MVaR]
+    A. Prekopa. Multivariate value at risk and related topics.
+    Annals of Operations Research, 2012.
+
+.. [Cousin2013MVaR]
+    A. Cousin and E. Di Bernardino. On multivariate extensions of Value-at-Risk.
+    Journal of Multivariate Analysis, 2013.
+"""
+
+import warnings
+from abc import ABC, abstractmethod
+from math import ceil
+from typing import Optional
+
+import torch
+from botorch.acquisition.multi_objective.objective import MCMultiOutputObjective
+from botorch.acquisition.risk_measures import CVaR, RiskMeasureMCObjective
+from botorch.utils.multi_objective.pareto import is_non_dominated
+from torch import Tensor
+
+
+class MultiOutputRiskMeasureMCObjective(
+    RiskMeasureMCObjective, MCMultiOutputObjective, ABC
+):
+    r"""Objective transforming the multi-output posterior samples to samples
+    of a multi-output risk measure.
+
+    The risk measure is calculated over joint q-batch samples from the posterior.
+    If the q-batch includes samples corresponding to multiple inputs, it is assumed
+    that first `n_w` samples correspond to first input, second `n_w` samples
+    correspond to second input, etc.
+    """
+
+    def __init__(
+        self,
+        n_w: int,
+        weights: Optional[Tensor] = None,
+    ) -> None:
+        r"""Transform the posterior samples to samples of a risk measure.
+
+        Args:
+            n_w: The size of the `w_set` to calculate the risk measure over.
+            weights: An optional `m`-dim tensor of weights for scaling
+                multi-output samples before calculating the risk measure.
+                This can also be used to make sure that all outputs are
+                correctly aligned for maximization by negating those that are
+                originally defined for minimization.
+        """
+        super().__init__(n_w=n_w, weights=weights)
+
+    def _prepare_samples(self, samples: Tensor) -> Tensor:
+        r"""Prepare samples for risk measure calculations by scaling and
+        separating out the q-batch dimension.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+
+        Returns:
+            A `sample_shape x batch_shape x q x n_w x m`-dim tensor of prepared samples.
+        """
+        if self.weights is not None:
+            samples = samples * self.weights
+        return samples.view(*samples.shape[:-2], -1, self.n_w, samples.shape[-1])
+
+    @abstractmethod
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the risk measure corresponding to the given samples.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of risk measure samples.
+        """
+        pass  # pragma: no cover
+
+
+class IndependentCVaR(CVaR, MultiOutputRiskMeasureMCObjective):
+    r"""The multi-output Conditional Value-at-Risk risk measure that operates on
+    each output dimension independently. Since this does not consider the joint
+    distribution of the outputs (i.e., that the outputs were evaluated on same
+    perturbed input and are not independent), the risk estimates provided by
+    `IndependentCVaR` in general are more optimistic than the definition of CVaR
+    would suggest.
+
+    The Conditional Value-at-Risk measures the expectation of the worst outcomes
+    (small rewards or large losses) with a total probability of `1 - alpha`. It
+    is commonly defined as the conditional expectation of the reward function,
+    with the condition that the reward is smaller than the corresponding
+    Value-at-Risk (also defined below).
+
+    NOTE: Due to the use of a discrete `w_set` of samples, the VaR and CVaR
+    calculated here are (possibly biased) Monte-Carlo approximations of the
+    true risk measures.
+    """
+
+    def _get_sorted_prepared_samples(self, samples: Tensor) -> Tensor:
+        r"""Get the prepared samples that are sorted over the `n_w` dimension.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+
+        Returns:
+            A `sample_shape x batch_shape x q x n_w x m`-dim tensor of sorted samples.
+        """
+        prepared_samples = self._prepare_samples(samples)
+        return prepared_samples.sort(dim=-2, descending=True).values
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the CVaR corresponding to the given samples.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of CVaR samples.
+        """
+        sorted_samples = self._get_sorted_prepared_samples(samples)
+        return sorted_samples[..., self.alpha_idx :, :].mean(dim=-2)
+
+
+class IndependentVaR(IndependentCVaR):
+    r"""The multi-output Value-at-Risk risk measure that operates on each output
+    dimension independently. For the same reasons as `IndependentCVaR`, the risk
+    estimates provided by this are in general more optimistic than the definition
+    of VaR would suggest.
+
+    Value-at-Risk measures the smallest possible reward (or largest possible loss)
+    after excluding the worst outcomes with a total probability of `1 - alpha`. It
+    is commonly used in financial risk management, and it corresponds to the
+    `1 - alpha` quantile of a given random variable.
+    """
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the VaR corresponding to the given samples.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of VaR samples.
+        """
+        sorted_samples = self._get_sorted_prepared_samples(samples)
+        return sorted_samples[..., self.alpha_idx, :]
+
+
+class MultiOutputWorstCase(MultiOutputRiskMeasureMCObjective):
+    r"""The multi-output worst-case risk measure."""
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the worst-case measure corresponding to the given samples.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of worst-case samples.
+        """
+        prepared_samples = self._prepare_samples(samples)
+        return prepared_samples.min(dim=-2).values
+
+
+class MVaR(MultiOutputRiskMeasureMCObjective):
+    r"""The multivariate Value-at-Risk as introduced in [Prekopa2012MVaR]_.
+
+    MVaR is defined as the non-dominated set of points in the extended domain
+    of the random variable that have multivariate CDF greater than or equal to
+    `alpha`. Note that MVaR is set valued and the size of the set depends on the
+    particular realizations of the random variable. [Cousin2013MVaR]_ instead
+    propose to use the expectation of the set-valued MVaR as the multivariate
+    VaR. We support this alternative with an `expectation` flag. Default: True.
+    """
+
+    def __init__(
+        self,
+        n_w: int,
+        alpha: float,
+        expectation: bool = False,
+        weights: Optional[Tensor] = None,
+        pad_to_n_w: bool = False,
+        filter_dominated: bool = True,
+    ) -> None:
+        r"""The multivariate Value-at-Risk.
+
+        Args:
+            n_w: The size of the `w_set` to calculate the risk measure over.
+            alpha: The risk level of MVaR, float in `(0.0, 1.0]`. Each MVaR value
+                dominates `alpha` fraction of all observations.
+            expectation: If True, returns the expectation of the MVaR set as is
+                done in [Cousin2013MVaR]_. Otherwise, it returns the union of all
+                values in the MVaR set. Default: True.
+            weights: An optional `m`-dim tensor of weights for scaling
+                multi-output samples before calculating the risk measure.
+                This can also be used to make sure that all outputs are
+                correctly aligned for maximization by negating those that are
+                originally defined for minimization.
+            pad_to_n_w: If True, instead of padding up to `k'`, which is the size of
+                the largest MVaR set across all batches, we pad the MVaR set up to
+                `n_w`. This produces a return tensor of known size, however, it may
+                in general be much larger than the alternative. See `forward` for
+                more details on the return shape.
+                NOTE: this is only relevant if `expectation=False`.
+            filter_dominated: If True, returns the non-dominated subset of
+                alpha level points (this is MVaR as defined by [Prekopa2012MVaR]_).
+                Disabling this will make this faster, and may be preferable if
+                the dominated points will be filtered out later, e.g., while
+                calculating the hypervolume. Disabling this is not recommended
+                if `expectation=True.
+        """
+        super().__init__(n_w=n_w, weights=weights)
+        if not 0 < alpha <= 1:
+            raise ValueError("`alpha` must be in (0.0, 1.0]")
+        self.alpha = alpha
+        self.expectation = expectation
+        self.pad_to_n_w = pad_to_n_w
+        self.filter_dominated = filter_dominated
+
+    def get_mvar_set_cpu(self, Y: Tensor) -> Tensor:
+        r"""Find MVaR set based on the definition in [Prekopa2012MVaR]_.
+
+        NOTE: This is much faster on CPU for large `n_w` than the alternative but it
+        is significantly slower on GPU. Based on empirical evidence, this is recommended
+        when running on CPU with `n_w > 64`.
+
+        This first calculates the CDF for each point on the extended domain of the
+        random variable (the grid defined by the given samples), then takes the
+        values with CDF equal to (rounded if necessary) `alpha`. The non-dominated
+        subset of these form the MVaR set.
+
+        Args:
+            Y: A `batch x n_w x m`-dim tensor of outcomes. This is currently
+                restricted to `m = 2` objectives.
+                TODO: Support `m > 2` objectives.
+
+        Returns:
+            A `batch` length list of `k x m`-dim tensor of MVaR values, where `k`
+            depends on the corresponding batch inputs. Note that MVaR values in general
+            are not in-sample points.
+        """
+        if Y.dim() == 3:
+            return [self.get_mvar_set_cpu(y_) for y_ in Y]
+        m = Y.shape[-1]
+        if m != 2:  # pragma: no covar
+            raise ValueError("`get_mvar_set_cpu` only supports `m=2` outcomes!")
+        # Generate sets of all unique values in each output dimension.
+        unique_outcomes = [Y[:, i].unique(sorted=True).tolist()[::-1] for i in range(m)]
+        # Convert this into a list of m dictionaries mapping values to indices.
+        unique_outcomes = [
+            dict(zip(outcomes, range(len(outcomes)))) for outcomes in unique_outcomes
+        ]
+        # Initialize a tensor counting the number of points in Y that a given grid point
+        # is dominated by. This will essentially be a non-normalized CDF.
+        counter_tensor = torch.zeros(
+            [len(outcomes) for outcomes in unique_outcomes],
+            dtype=torch.long,
+            device=Y.device,
+        )
+        # populate the tensor, counting the dominated points.
+        for y_ in Y:
+            starting_idcs = [unique_outcomes[i][y_[i].item()] for i in range(m)]
+            counter_tensor[starting_idcs[0] :, starting_idcs[1] :] += 1
+        # Get the count alpha-level points should have.
+        alpha_count = ceil(self.alpha * self.n_w)
+        # Get the alpha level indices.
+        alpha_level_indices = (counter_tensor == alpha_count).nonzero(as_tuple=False)
+        # If there are no exact alpha level points, get the smallest alpha' > alpha
+        # and find the corresponding alpha level indices.
+        if alpha_level_indices.numel() == 0:
+            min_greater_than_alpha = counter_tensor[counter_tensor > alpha_count].min()
+            alpha_level_indices = (counter_tensor == min_greater_than_alpha).nonzero(
+                as_tuple=False
+            )
+        unique_outcomes = [
+            torch.as_tensor(list(outcomes.keys()), device=Y.device, dtype=Y.dtype)
+            for outcomes in unique_outcomes
+        ]
+        alpha_level_points = torch.stack(
+            [
+                unique_outcomes[i][alpha_level_indices[:, i]]
+                for i in range(len(unique_outcomes))
+            ],
+            dim=-1,
+        )
+        # MVaR is simply the non-dominated subset of alpha level points.
+        if self.filter_dominated:
+            mask = is_non_dominated(alpha_level_points)
+            mvar = alpha_level_points[mask]
+        else:
+            mvar = alpha_level_points
+        return mvar
+
+    def get_mvar_set_gpu(self, Y: Tensor) -> Tensor:
+        r"""Find MVaR set based on the definition in [Prekopa2012MVaR]_.
+
+        NOTE: This is much faster on GPU than the alternative but it scales very poorly
+        on CPU as `n_w` increases. This should be preferred if a GPU is available or
+        when `n_w <= 64`. In addition, this supports `m >= 2` outcomes (vs `m = 2` for
+        the CPU version) and it should be used if `m > 2`.
+
+        This first calculates the CDF for each point on the extended domain of the
+        random variable (the grid defined by the given samples), then takes the
+        values with CDF equal to (rounded if necessary) `alpha`. The non-dominated
+        subset of these form the MVaR set.
+
+        Args:
+            Y: A `batch x n_w x m`-dim tensor of observations.
+
+        Returns:
+            A `batch` length list of `k x m`-dim tensor of MVaR values, where `k`
+            depends on the corresponding batch inputs. Note that MVaR values in general
+            are not in-sample points.
+        """
+        if Y.dim() == 2:
+            Y = Y.unsqueeze(0)
+        batch, m = Y.shape[0], Y.shape[-1]
+        # `y_grid` is the grid formed by all inputs in each batch.
+        if m == 2:
+            # This is significantly faster but only works with m=2.
+            y_grid = torch.stack(
+                [
+                    Y[..., 0].repeat_interleave(repeats=self.n_w, dim=-1),
+                    Y[..., 1].repeat(1, self.n_w),
+                ],
+                dim=-1,
+            )
+        else:
+            y_grid = torch.stack(
+                [
+                    torch.stack(
+                        torch.meshgrid([Y[b, :, i] for i in range(m)]),
+                        dim=-1,
+                    ).view(-1, m)
+                    for b in range(batch)
+                ],
+                dim=0,
+            )
+        # Get the non-normalized CDF.
+        cdf = (Y.unsqueeze(-2) >= y_grid.unsqueeze(-3)).all(dim=-1).sum(dim=-2)
+        # Get the alpha level points
+        alpha_count = ceil(self.alpha * self.n_w)
+        # NOTE: Need to loop here since mvar may have different shapes.
+        mvar = []
+        for b in range(batch):
+            alpha_level_points = y_grid[b][cdf[b] == alpha_count]
+            # If there are no exact alpha level points, get the smallest alpha' > alpha
+            # and find the corresponding alpha level indices.
+            if alpha_level_points.numel() == 0:
+                min_greater_than_alpha = cdf[b][cdf[b] > alpha_count].min()
+                alpha_level_points = y_grid[b][cdf[b] == min_greater_than_alpha]
+            # MVaR is the non-dominated subset of alpha level points.
+            if self.filter_dominated:
+                mask = is_non_dominated(alpha_level_points)
+                mvar.append(alpha_level_points[mask])
+            else:
+                mvar.append(alpha_level_points)
+        return mvar
+
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        r"""Calculate the MVaR corresponding to the given samples.
+
+        Args:
+            samples: A `sample_shape x batch_shape x (q * n_w) x m`-dim tensor of
+                posterior samples. The q-batches should be ordered so that each
+                `n_w` block of samples correspond to the same input.
+            X: A `batch_shape x q x d`-dim tensor of inputs. Ignored.
+
+        Returns:
+            A `sample_shape x batch_shape x q x m`-dim tensor of MVaR values,
+            if `self.expectation=True`.
+            Otherwise, this returns a `sample_shape x batch_shape x (q * k') x m`-dim
+            tensor, where `k'` is the maximum `k` across all batches that is returned
+            by `get_mvar_set_...`. Each `(q * k') x m` corresponds to the `k` MVaR
+            values for each `q` batch of `n_w` inputs, padded up to `k'` by repeating
+            the last element. If `self.pad_to_n_w`, we set `k' = self.n_w`, producing
+            a deterministic return shape.
+        """
+        batch_shape, m = samples.shape[:-2], samples.shape[-1]
+        prepared_samples = self._prepare_samples(samples)
+        # This is -1 x n_w x m.
+        prepared_samples = prepared_samples.reshape(-1, *prepared_samples.shape[-2:])
+        # Get the mvar set using the appropriate method based on device, m & n_w.
+        # NOTE: The `n_w <= 64` part is based on testing on a 24 core CPU.
+        # `get_mvar_set_gpu` heavily relies on parallelized batch computations and
+        # may scale worse on CPUs with fewer cores.
+        # Using `no_grad` here since `MVaR` is not differentiable.
+        with torch.no_grad():
+            if (
+                samples.device == torch.device("cpu")
+                and m == 2
+                and prepared_samples.shape[-2] <= 64
+            ):
+                mvar_set = self.get_mvar_set_cpu(prepared_samples)
+            else:
+                mvar_set = self.get_mvar_set_gpu(prepared_samples)
+        if samples.requires_grad:
+            # TODO: Investigate differentiability of MVaR.
+            warnings.warn(
+                "Got `samples` that requires grad, but computing MVaR involves "
+                "non-differentable operations and the results will not be "
+                "differentiable. This may lead to errors down the line!",
+                RuntimeWarning,
+            )
+        # Set the `pad_size` to either `self.n_w` or the size of the largest MVaR set.
+        pad_size = self.n_w if self.pad_to_n_w else max([_.shape[0] for _ in mvar_set])
+        padded_mvar_list = []
+        for mvar_ in mvar_set:
+            if self.expectation:
+                padded_mvar_list.append(mvar_.mean(dim=0))
+            else:
+                # Repeat the last entry to make `mvar_set` `n_w x m`.
+                repeats_needed = pad_size - mvar_.shape[0]
+                padded_mvar_list.append(
+                    torch.cat([mvar_, mvar_[-1].expand(repeats_needed, m)], dim=0)
+                )
+        mvars = torch.stack(padded_mvar_list, dim=0)
+        return mvars.view(*batch_shape, -1, m)

--- a/test/acquisition/multi_objective/test_multi_output_risk_measures.py
+++ b/test/acquisition/multi_objective/test_multi_output_risk_measures.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from typing import Optional
+
+import torch
+from botorch.utils.multi_objective.pareto import is_non_dominated
+from botorch.utils.testing import BotorchTestCase
+from botorch_fb.acquisition.multi_output_risk_measures import (
+    IndependentCVaR,
+    IndependentVaR,
+    MultiOutputRiskMeasureMCObjective,
+    MultiOutputWorstCase,
+    MVaR,
+)
+from torch import Tensor
+
+
+class NotSoAbstractMORiskMeasure(MultiOutputRiskMeasureMCObjective):
+    def forward(self, samples: Tensor, X: Optional[Tensor] = None) -> Tensor:
+        prepared_samples = self._prepare_samples(samples)
+        return prepared_samples.sum(dim=-2)
+
+
+class TestMultiOutputRiskMeasureMCObjective(BotorchTestCase):
+    def test_multi_output_risk_measure_mc_objective(self):
+        # abstract raises
+        with self.assertRaises(TypeError):
+            MultiOutputRiskMeasureMCObjective(n_w=3)
+
+        for dtype in (torch.float, torch.double):
+            samples = torch.tensor(
+                [
+                    [
+                        [1.0, 1.2],
+                        [0.5, 0.7],
+                        [2.0, 2.2],
+                        [3.0, 3.4],
+                        [1.0, 1.2],
+                        [5.0, 5.6],
+                    ]
+                ],
+                device=self.device,
+                dtype=dtype,
+            )
+            obj = NotSoAbstractMORiskMeasure(n_w=3, weights=None)
+            # test _prepare_samples
+            expected_samples = samples.view(1, 2, 3, 2)
+            prepared_samples = obj._prepare_samples(samples)
+            self.assertTrue(torch.equal(prepared_samples, expected_samples))
+            # test batches
+            samples = torch.rand(5, 3, 6, 3, device=self.device, dtype=dtype)
+            expected_samples = samples.view(5, 3, 2, 3, 3)
+            prepared_samples = obj._prepare_samples(samples)
+            self.assertTrue(torch.equal(prepared_samples, expected_samples))
+            # negating with weights
+            obj = NotSoAbstractMORiskMeasure(
+                n_w=3,
+                weights=torch.tensor(
+                    [-1.0, -1.0, -1.0], device=self.device, dtype=dtype
+                ),
+            )
+            prepared_samples = obj._prepare_samples(samples)
+            self.assertTrue(torch.equal(prepared_samples, -expected_samples))
+
+
+class TestIndependentCVaR(BotorchTestCase):
+    def test_independent_cvar(self):
+        obj = IndependentCVaR(alpha=0.5, n_w=3)
+        self.assertEqual(obj.alpha_idx, 1)
+        with self.assertRaises(ValueError):
+            IndependentCVaR(alpha=3, n_w=3)
+        for dtype in (torch.float, torch.double):
+            obj = IndependentCVaR(alpha=0.5, n_w=3)
+            samples = torch.tensor(
+                [
+                    [
+                        [1.0, 1.2],
+                        [0.5, 0.7],
+                        [2.0, 2.2],
+                        [3.0, 1.2],
+                        [1.0, 7.2],
+                        [5.0, 5.8],
+                    ]
+                ],
+                device=self.device,
+                dtype=dtype,
+            )
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.allclose(
+                    rm_samples,
+                    torch.tensor(
+                        [[[0.75, 0.95], [2.0, 3.5]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+            # w/ first output negated
+            obj.weights = torch.tensor([-1.0, 1.0], device=self.device, dtype=dtype)
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.allclose(
+                    rm_samples,
+                    torch.tensor(
+                        [[[-1.5, 0.95], [-4.0, 3.5]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+
+
+class TestIndependentVaR(BotorchTestCase):
+    def test_independent_var(self):
+        for dtype in (torch.float, torch.double):
+            obj = IndependentVaR(alpha=0.5, n_w=3)
+            samples = torch.tensor(
+                [
+                    [
+                        [1.0, 3.2],
+                        [0.5, 0.7],
+                        [2.0, 2.2],
+                        [3.0, 1.2],
+                        [1.0, 7.2],
+                        [5.0, 5.8],
+                    ]
+                ],
+                device=self.device,
+                dtype=dtype,
+            )
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor(
+                        [[[1.0, 2.2], [3.0, 5.8]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+            # w/ weights
+            obj.weights = torch.tensor([0.5, -1.0], device=self.device, dtype=dtype)
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor(
+                        [[[0.5, -2.2], [1.5, -5.8]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+
+
+class TestMultiOutputWorstCase(BotorchTestCase):
+    def test_multi_output_worst_case(self):
+        for dtype in (torch.float, torch.double):
+            obj = MultiOutputWorstCase(n_w=3)
+            samples = torch.tensor(
+                [
+                    [
+                        [1.0, 3.2],
+                        [5.5, 0.7],
+                        [2.0, 2.2],
+                        [3.0, 1.2],
+                        [5.0, 7.2],
+                        [5.0, 5.8],
+                    ]
+                ],
+                device=self.device,
+                dtype=dtype,
+            )
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor(
+                        [[[1.0, 0.7], [3.0, 1.2]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+            # w/ weights
+            obj.weights = torch.tensor([-1.0, 2.0], device=self.device, dtype=dtype)
+            rm_samples = obj(samples)
+            self.assertTrue(
+                torch.equal(
+                    rm_samples,
+                    torch.tensor(
+                        [[[-5.5, 1.4], [-5.0, 2.4]]], device=self.device, dtype=dtype
+                    ),
+                )
+            )
+
+
+class TestMVaR(BotorchTestCase):
+    def test_mvar(self):
+        with self.assertRaises(ValueError):
+            MVaR(n_w=5, alpha=3.0)
+
+        def set_equals(t1: Tensor, t2: Tensor) -> bool:
+            r"""Check if two `k x m`-dim tensors are equivalent after possibly
+            reordering the `k` dimension. Ignores duplicate entries.
+            """
+            t1 = t1.unique(dim=0)
+            t2 = t2.unique(dim=0)
+            if t1.shape != t2.shape:
+                return False
+            equals_sum = (t1.unsqueeze(-2) == t2).all(dim=-1).sum(dim=-1)
+            return torch.equal(equals_sum, torch.ones_like(equals_sum))
+
+        for dtype in (torch.float, torch.double):
+            tkwargs = {"device": self.device, "dtype": dtype}
+            mvar = MVaR(n_w=5, alpha=0.6)
+            # a simple negatively correlated example
+            Y = torch.stack(
+                [torch.linspace(1, 5, 5), torch.linspace(5, 1, 5)],
+                dim=-1,
+            ).to(**tkwargs)
+            expected_set = torch.stack(
+                [torch.linspace(1, 3, 3), torch.linspace(3, 1, 3)],
+                dim=-1,
+            )
+            # check that both versions produce the correct set
+            cpu_mvar = mvar.get_mvar_set_cpu(Y)  # For 2d input, returns k x m
+            gpu_mvar = mvar.get_mvar_set_gpu(Y)[0]  # returns a batch list of k x m
+            self.assertTrue(set_equals(cpu_mvar, gpu_mvar))
+            self.assertTrue(set_equals(cpu_mvar, expected_set))
+            # check that the `filter_dominated` works correctly
+            mvar = MVaR(
+                n_w=5,
+                alpha=0.4,
+                filter_dominated=False,
+            )
+            # negating the input to treat large values as undesirable
+            Y = -torch.tensor(
+                [
+                    [1, 4],
+                    [2, 3],
+                    [3, 2],
+                    [4, 1],
+                    [3.5, 3.5],
+                ],
+                **tkwargs
+            )
+            cpu_mvar = mvar.get_mvar_set_cpu(Y)
+            gpu_mvar = mvar.get_mvar_set_gpu(Y)[0]
+            self.assertTrue(set_equals(cpu_mvar, gpu_mvar))
+            # negating here as well
+            expected_w_dominated = -torch.tensor(
+                [
+                    [2, 4],
+                    [3, 3],
+                    [3.5, 3],
+                    [3, 3.5],
+                    [4, 2],
+                ],
+                **tkwargs
+            )
+            self.assertTrue(set_equals(cpu_mvar, expected_w_dominated))
+            expected_non_dominated = expected_w_dominated[
+                is_non_dominated(expected_w_dominated)
+            ]
+            mvar.filter_dominated = True
+            cpu_mvar = mvar.get_mvar_set_cpu(Y)
+            gpu_mvar = mvar.get_mvar_set_gpu(Y)[0]
+            self.assertTrue(set_equals(cpu_mvar, gpu_mvar))
+            self.assertTrue(set_equals(cpu_mvar, expected_non_dominated))
+
+            # test batched w/ random input
+            mvar = MVaR(
+                n_w=10,
+                alpha=0.5,
+                filter_dominated=False,
+            )
+            Y = torch.rand(4, 10, 2, **tkwargs)
+            cpu_mvar = mvar.get_mvar_set_cpu(Y)
+            gpu_mvar = mvar.get_mvar_set_gpu(Y)
+            # check that the two agree
+            self.assertTrue(
+                all([set_equals(cpu_mvar[i], gpu_mvar[i]) for i in range(4)])
+            )
+            # check that the MVaR is dominated by `alpha` fraction (maximization).
+            dominated_count = (Y[0].unsqueeze(-2) >= cpu_mvar[0]).all(dim=-1).sum(dim=0)
+            expected_count = (
+                torch.ones(cpu_mvar[0].shape[0], device=self.device, dtype=torch.long)
+                * 5
+            )
+            self.assertTrue(torch.equal(dominated_count, expected_count))
+
+            # test forward pass
+            # with `expectation=True`
+            mvar = MVaR(
+                n_w=10,
+                alpha=0.5,
+                expectation=True,
+            )
+            samples = torch.rand(2, 20, 2, **tkwargs)
+            mvar_exp = mvar(samples)
+            expected = [
+                mvar.get_mvar_set_cpu(Y).mean(dim=0) for Y in samples.view(4, 10, 2)
+            ]
+            self.assertTrue(torch.equal(mvar_exp, torch.stack(expected).view(2, 2, 2)))
+
+            # m > 2
+            samples = torch.rand(2, 20, 3, **tkwargs)
+            mvar_exp = mvar(samples)
+            expected = [
+                mvar.get_mvar_set_gpu(Y)[0].mean(dim=0) for Y in samples.view(4, 10, 3)
+            ]
+            self.assertTrue(torch.equal(mvar_exp, torch.stack(expected).view(2, 2, 3)))
+
+            # with `expectation=False`
+            mvar = MVaR(
+                n_w=10,
+                alpha=0.5,
+                expectation=False,
+                pad_to_n_w=True,
+            )
+            samples = torch.rand(2, 20, 2, **tkwargs)
+            mvar_vals = mvar(samples)
+            self.assertTrue(mvar_vals.shape == samples.shape)
+            expected = [mvar.get_mvar_set_cpu(Y) for Y in samples.view(4, 10, 2)]
+            for i in range(4):
+                batch_idx = i // 2
+                q_idx_start = 10 * (i % 2)
+                expected_ = expected[i]
+                # check that the actual values are there
+                self.assertTrue(
+                    set_equals(
+                        mvar_vals[
+                            batch_idx, q_idx_start : q_idx_start + expected_.shape[0]
+                        ],
+                        expected_,
+                    )
+                )
+                # check for correct padding
+                self.assertTrue(
+                    torch.equal(
+                        mvar_vals[
+                            batch_idx,
+                            q_idx_start + expected_.shape[0] : q_idx_start + 10,
+                        ],
+                        mvar_vals[
+                            batch_idx, q_idx_start + expected_.shape[0] - 1
+                        ].expand(10 - expected_.shape[0], -1),
+                    )
+                )
+
+            # Test the no-exact alpha level points case.
+            # This happens when there are duplicates in the input.
+            Y = torch.ones(10, 2, **tkwargs)
+            cpu_mvar = mvar.get_mvar_set_cpu(Y)
+            gpu_mvar = mvar.get_mvar_set_gpu(Y)[0]
+            self.assertTrue(torch.equal(cpu_mvar, Y[:1]))
+            self.assertTrue(torch.equal(cpu_mvar, Y[:1]))
+
+            # TODO: Test grad support once properly implemented.


### PR DESCRIPTION
Summary: Move multi-output risk measures to open source botorch.

Differential Revision: D30295449

fbshipit-source-id: cbca77726f9b1834b2550a57619e4ec537053e23

<!--
Thank you for sending the PR! We appreciate you spending the time to make BoTorch better.

Help us understand your motivation by explaining why you decided to make this change.

You can learn more about contributing to BoTorch here: https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md
-->

## Motivation

(Write your motivation here.)

### Have you read the [Contributing Guidelines on pull requests](https://github.com/pytorch/botorch/blob/main/CONTRIBUTING.md#pull-requests)?

(Write your answer here.)

## Test Plan

(Write your test plan here. If you changed any code, please provide us with clear instructions on how you verified your changes work. Bonus points for screenshots and videos!)

## Related PRs

(If this PR adds or changes functionality, please take some time to update the docs at https://github.com/pytorch/botorch, and link to your PR here.)
